### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "wikibase-solutions/php-cypher-dsl",
   "description": "A query builder for the Cypher query language written in PHP",
-  "version": "2.8.0",
   "type": "library",
   "keywords": [
     "neo4j",


### PR DESCRIPTION
According to the `composer.json` schema, the version should be omitted from the `composer.json` file whenever it can be inferred from somewhere. We use annotated tags for each new release of php-cypher-dsl, so Composer will now infer the version from there. This reduces the risk of problems resulting from forgetting to update the tag.