### PR TITLE
Allow minhops of 0

### DIFF
--- a/src/Patterns/Path.php
+++ b/src/Patterns/Path.php
@@ -182,8 +182,8 @@ class Path implements PathType
      */
     public function withMinHops(int $minHops): self
     {
-        if ($minHops < 1) {
-            throw new DomainException("minHops cannot be less than 1");
+        if ($minHops < 0) {
+            throw new DomainException("minHops cannot be less than 0");
         }
 
         if (isset($this->maxHops) && $minHops > $this->maxHops) {

--- a/tests/Unit/Patterns/RelationshipTest.php
+++ b/tests/Unit/Patterns/RelationshipTest.php
@@ -378,15 +378,6 @@ class RelationshipTest extends TestCase
         $r->withMinHops(100);
     }
 
-    public function testMinHopsLessThanOne()
-    {
-        $r = new Path($this->a, $this->b, Path::DIR_RIGHT);
-
-        $this->expectException(DomainException::class);
-
-        $r->withMinHops(0);
-    }
-
     public function testMinHopsLessThanZero()
     {
         $r = new Path($this->a, $this->b, Path::DIR_RIGHT);


### PR DESCRIPTION
See e.g. [this page](https://graphaware.com/graphaware/2015/05/19/neo4j-cypher-variable-length-relationships-by-example.html#zero-length-paths), zero minhops are useful

There is already a unit test for <0 hops, so no new tests needed