### PR TITLE
Order by rework

### DIFF
--- a/src/Clauses/OrderByClause.php
+++ b/src/Clauses/OrderByClause.php
@@ -21,8 +21,10 @@
 
 namespace WikibaseSolutions\CypherDSL\Clauses;
 
+use WikibaseSolutions\CypherDSL\Order;
 use WikibaseSolutions\CypherDSL\Property;
 use WikibaseSolutions\CypherDSL\Traits\EscapeTrait;
+use function array_map;
 
 /**
  * This class represents an ORDER BY clause. This clause should always be preceded by a RETURN
@@ -35,9 +37,9 @@ class OrderByClause extends Clause
     use EscapeTrait;
 
     /**
-     * @var Property[] The expressions to include in the clause
+     * @var Order[] The expressions to include in the clause
      */
-    private array $properties = [];
+    private array $orderings = [];
 
     /**
      * @var bool
@@ -47,12 +49,14 @@ class OrderByClause extends Clause
     /**
      * Add a property to sort on.
      *
-     * @param Property $property The additional property to sort on
+     * @param Property $property The additional property to sort on.
+     * @param string|null $order The order of the property to appear. Null is equal to the default in Neo4J.
+     *
      * @return OrderByClause
      */
-    public function addProperty(Property $property): self
+    public function addProperty(Property $property, ?string $order = null): self
     {
-        $this->properties[] = $property;
+        $this->orderings[] = new Order($property, $order);
 
         return $this;
     }
@@ -60,34 +64,21 @@ class OrderByClause extends Clause
     /**
      * Returns the properties to order.
      *
-     * @return Property[]
+     * @return Order[]
      */
     public function getProperties(): array
     {
-        return $this->properties;
+        return array_map(static fn (Order $o) => $o->getExpression(), $this->orderings);
     }
 
     /**
-     * Returns whether the ordering is in descending order.
+     * Returns the orderings.
      *
-     * @return bool
+     * @return Property[]
      */
-    public function isDescending(): bool
+    public function getOrderings(): array
     {
-        return $this->descending;
-    }
-
-    /**
-     * Set to sort in a DESCENDING order.
-     *
-     * @param bool $descending
-     * @return OrderByClause
-     */
-    public function setDescending(bool $descending = true): self
-    {
-        $this->descending = $descending;
-
-        return $this;
+        return $this->orderings;
     }
 
     /**
@@ -103,9 +94,8 @@ class OrderByClause extends Clause
      */
     protected function getSubject(): string
     {
-        $properties = array_map(fn (Property $property): string => $property->toQuery(), $this->properties);
-        $subject = implode(", ", $properties);
+        $properties = array_map(static fn ($x) => $x->toQuery(), $this->orderings);
 
-        return $this->descending ? sprintf("%s DESCENDING", $subject) : $subject;
+        return implode(", ", $properties);
     }
 }

--- a/src/Order.php
+++ b/src/Order.php
@@ -11,6 +11,10 @@ use function strtoupper;
  * Defines the order of an expression. Can only be used in an ORDER BY clause.
  *
  * @see https://neo4j.com/docs/cypher-manual/current/clauses/order-by/
+ * @note While the documentation online does not mention this, ORDER BY supports multiple directions in the same clause:
+ *      - ORDER BY a ASC, b DESC
+ *      is considered valid.
+ *      This means it is impossible for the OrderBy clause to order all expressions individually, necessitating this class.
  */
 class Order implements QueryConvertable
 {
@@ -19,7 +23,7 @@ class Order implements QueryConvertable
     private ?string $ordering;
 
     /**
-     * The expression to order
+     * Order constructor.
      *
      * @param AnyType $expression The expression to order by.
      * @param string|null $ordering The order modifier. Must be null or a valid modifier ('ASC', 'ASCENDING', 'DESC', 'DESCENDING')

--- a/src/Order.php
+++ b/src/Order.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace WikibaseSolutions\CypherDSL;
+
+use InvalidArgumentException;
+use WikibaseSolutions\CypherDSL\Types\AnyType;
+use function in_array;
+use function strtoupper;
+
+/**
+ * Defines the order of an expression. Can only be used in an ORDER BY clause.
+ *
+ * @see https://neo4j.com/docs/cypher-manual/current/clauses/order-by/
+ */
+class Order implements QueryConvertable
+{
+    private AnyType $expression;
+    /** @var string|null */
+    private ?string $ordering;
+
+    /**
+     * The expression to order
+     *
+     * @param AnyType $expression The expression to order by.
+     * @param string|null $ordering The order modifier. Must be null or a valid modifier ('ASC', 'ASCENDING', 'DESC', 'DESCENDING')
+     */
+    public function __construct(AnyType $expression, ?string $ordering = null)
+    {
+        $this->expression = $expression;
+        $this->setOrdering($ordering);
+    }
+
+    /**
+     * Returns the expression being ordered.
+     *
+     * @return AnyType
+     */
+    public function getExpression(): AnyType
+    {
+        return $this->expression;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getOrdering(): ?string
+    {
+        return $this->ordering;
+    }
+
+    public function setOrdering(?string $ordering): self
+    {
+        if ($ordering !== null) {
+            $ordering = strtoupper($ordering);
+            if (!in_array($ordering, ['ASC', 'DESC', 'ASCENDING', 'DESCENDING']))  {
+                throw new InvalidArgumentException('Ordering must be null, "ASC", "DESC", "ASCENDING" or "DESCENDING"');
+            }
+
+            $this->ordering = $ordering;
+        } else {
+            $this->ordering = null;
+        }
+
+        return $this;
+    }
+
+    public function toQuery(): string
+    {
+        $cypher = $this->getExpression()->toQuery();
+        if ($this->ordering) {
+            $cypher .= ' ' . $this->ordering;
+        }
+
+        return $cypher;
+    }
+}

--- a/tests/Unit/OrderTest.php
+++ b/tests/Unit/OrderTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace WikibaseSolutions\CypherDSL\Tests\Unit;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use WikibaseSolutions\CypherDSL\Order;
+use WikibaseSolutions\CypherDSL\RawExpression;
+
+class OrderTest extends TestCase
+{
+    use TestHelper;
+
+    public function testBasicOrder(): void
+    {
+        $order = new Order($this->getQueryConvertableMock(RawExpression::class, 'x'));
+
+        $this->assertEquals('x', $order->toQuery());
+        $this->assertNull($order->getOrdering());
+    }
+
+    public function testBasicOrderDescending(): void
+    {
+        $order = new Order($this->getQueryConvertableMock(RawExpression::class, 'x'), 'desc');
+
+        $this->assertEquals('x DESC', $order->toQuery());
+        $this->assertEquals('DESC', $order->getOrdering());
+    }
+
+    public function testBasicOrderAscending(): void
+    {
+        $order = new Order($this->getQueryConvertableMock(RawExpression::class, 'x'), 'asc');
+
+        $this->assertEquals('x ASC', $order->toQuery());
+        $this->assertEquals('ASC', $order->getOrdering());
+    }
+
+    public function testBasicOrderChange(): void
+    {
+        $order = new Order($this->getQueryConvertableMock(RawExpression::class, 'x'), 'asc');
+
+        $order->setOrdering(null);
+
+        $this->assertEquals('x', $order->toQuery());
+        $this->assertNull($order->getOrdering());
+    }
+
+    public function testOrderFalse(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectErrorMessage('Ordering must be null, "ASC", "DESC", "ASCENDING" or "DESCENDING"');
+
+        new Order($this->getQueryConvertableMock(RawExpression::class, 'x'), 'ascc');
+    }
+}


### PR DESCRIPTION
Hello once again :wave: 

I just found out ORDER BY allows for order modifier for each property. This is possible:
`ORDER BY x.x ASC, x.y DESC`

For this reason I had to rework the OrderByClause to use Order objects and not worry about the order itself.

Looking forward to your feedback!