### PR TITLE
Be less strict about escaping.

### DIFF
--- a/src/Traits/ErrorTrait.php
+++ b/src/Traits/ErrorTrait.php
@@ -110,11 +110,8 @@ trait ErrorTrait
             throw new InvalidArgumentException("A name cannot be an empty string");
         }
 
-        if (!preg_match('/^\p{L}[\p{L}\d_]*$/u', $name)) {
-            throw new InvalidArgumentException('A name can only contain alphanumeric characters and underscores and must begin with an alphabetic character');
-        }
-
         if (strlen($name) >= 65535) {
+            // Remark: Actual limit depends on Neo4j version, but we just take the lower bound.
             throw new InvalidArgumentException('A name cannot be longer than 65534 characters');
         }
     }

--- a/src/Traits/ErrorTrait.php
+++ b/src/Traits/ErrorTrait.php
@@ -35,7 +35,6 @@ use function is_object;
 use function is_resource;
 use function is_string;
 use function key;
-use function preg_match;
 use function strpos;
 use TypeError;
 

--- a/src/Traits/EscapeTrait.php
+++ b/src/Traits/EscapeTrait.php
@@ -33,18 +33,16 @@ trait EscapeTrait
 {
     /**
      * Escapes a 'name' if it needs to be escaped.
+     * @see https://neo4j.com/docs/cypher-manual/4.4/syntax/naming
      * A 'name' in cypher is any string that should be included directly in a cypher query,
      * such as variable names, labels, property names and relation types
-     *
-     * Note that empty strings are usually not allowed as names, so these should not be passed to this function.
-     * However, some neo4j versions do not crash on empty string as variable name, so let's just escape them anyways.
      *
      * @param string $name
      * @return string
      */
     public static function escape(string $name): string
     {
-        if ($name !== '' && preg_match('/^\p{L}[\p{L}\d_]*$/u', $name)) {
+        if (preg_match('/^\p{L}[\p{L}\d_]*$/u', $name)) {
             return $name;
         }
 
@@ -57,7 +55,6 @@ trait EscapeTrait
      */
     public static function escapeRaw($name)
     {
-
         // Escape backticks that are included in $name by doubling them.
         $name = str_replace('`', '``', $name);
 

--- a/src/Traits/EscapeTrait.php
+++ b/src/Traits/EscapeTrait.php
@@ -21,7 +21,9 @@
 
 namespace WikibaseSolutions\CypherDSL\Traits;
 
-use InvalidArgumentException;
+use function preg_match;
+use function sprintf;
+use function str_replace;
 
 /**
  * Trait for encoding certain structures that are used in multiple clauses in a
@@ -53,10 +55,11 @@ trait EscapeTrait
      * Escapes the given $name to be used directly in a CYPHER query.
      * Note: according to https://github.com/neo4j/neo4j/issues/12901 backslashes might give problems in some Neo4j versions.
      */
-    public static function escapeRaw($name) {
+    public static function escapeRaw($name)
+    {
 
         // Escape backticks that are included in $name by doubling them.
-        $name = str_replace('`','``',$name);
+        $name = str_replace('`', '``', $name);
 
         return sprintf("`%s`", $name);
     }

--- a/tests/Unit/ParameterTest.php
+++ b/tests/Unit/ParameterTest.php
@@ -68,10 +68,7 @@ class ParameterTest extends TestCase
     {
         return [
             [""],
-            ["@"],
-            ["!"],
-            ["-"],
-            [''],
+            [str_repeat('a', 65535)],
         ];
     }
 }

--- a/tests/Unit/Patterns/NodeTest.php
+++ b/tests/Unit/Patterns/NodeTest.php
@@ -48,6 +48,7 @@ class NodeTest extends TestCase
         $this->assertSame($name, $node->getVariable());
     }
 
+    // Further tests can be found in Traits/EscapeTraitTest
     public function testBacktickIsEscaped(): void
     {
         $node = new Node();

--- a/tests/Unit/Patterns/NodeTest.php
+++ b/tests/Unit/Patterns/NodeTest.php
@@ -49,13 +49,12 @@ class NodeTest extends TestCase
         $this->assertSame($name, $node->getVariable());
     }
 
-    public function testBacktickThrowsException(): void
+    public function testBacktickIsEscaped(): void
     {
         $node = new Node();
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectDeprecationMessage('A name can only contain alphanumeric characters and underscores');
         $node->named('abcdr`eer');
+        $this->assertEquals('(`abcdr``eer`)', $node->toQuery());
     }
 
     /**

--- a/tests/Unit/Patterns/NodeTest.php
+++ b/tests/Unit/Patterns/NodeTest.php
@@ -21,7 +21,6 @@
 
 namespace WikibaseSolutions\CypherDSL\Tests\Unit\Patterns;
 
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use WikibaseSolutions\CypherDSL\ExpressionList;
 use WikibaseSolutions\CypherDSL\Literals\Decimal;

--- a/tests/Unit/QueryTest.php
+++ b/tests/Unit/QueryTest.php
@@ -762,7 +762,7 @@ class QueryTest extends TestCase
             ->returning([$tom, $tomHanksMovies])
             ->build();
 
-        $this->assertSame("MATCH (tom:Person {name: 'Tom Hanks'})-[:`ACTED_IN`]->(tomHanksMovies) RETURN tom, tomHanksMovies", $statement);
+        $this->assertSame("MATCH (tom:Person {name: 'Tom Hanks'})-[:ACTED_IN]->(tomHanksMovies) RETURN tom, tomHanksMovies", $statement);
 
         $cloudAtlas = Query::variable("cloudAtlas");
         $cloudAtlasNode = Query::node()
@@ -795,7 +795,7 @@ class QueryTest extends TestCase
             ->returning($coActors->property("name"))
             ->build();
 
-        $this->assertSame("MATCH (tom:Person {name: 'Tom Hanks'})-[:`ACTED_IN`]->(m)<-[:`ACTED_IN`]-(coActors) RETURN coActors.name", $statement);
+        $this->assertSame("MATCH (tom:Person {name: 'Tom Hanks'})-[:ACTED_IN]->(m)<-[:ACTED_IN]-(coActors) RETURN coActors.name", $statement);
 
         /*
          * @see https://gitlab.wikibase.nl/community/libraries/php-cypher-dsl/-/wikis/Usage/Clauses/CALL-procedure-clause

--- a/tests/Unit/Traits/EscapeTraitTest.php
+++ b/tests/Unit/Traits/EscapeTraitTest.php
@@ -21,7 +21,6 @@
 
 namespace WikibaseSolutions\CypherDSL\Tests\Unit\Traits;
 
-use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use WikibaseSolutions\CypherDSL\Traits\EscapeTrait;

--- a/tests/Unit/Traits/EscapeTraitTest.php
+++ b/tests/Unit/Traits/EscapeTraitTest.php
@@ -66,11 +66,9 @@ class EscapeTraitTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testValueWithBacktickThrowsException()
+    public function testValueWithBacktickIsProperlyEscaped()
     {
-        $this->expectException(InvalidArgumentException::class);
-
-        $this->trait->escape("foo`bar");
+        $this->assertSame('`foo``bar`', $this->trait->escape("foo`bar"));
     }
 
     public function provideSafeValueIsNotEscapedData(): array
@@ -79,45 +77,23 @@ class EscapeTraitTest extends TestCase
             ['foobar'],
             ['fooBar'],
             ['FOOBAR'],
+            ['foo_bar'],
+            ['FOO_BAR'],
             ['aaa'],
-            ['bbb'],
-            ['ccc'],
-            ['ddd'],
-            ['eee'],
-            ['fff'],
-            ['ggg'],
-            ['hhh'],
-            ['iii'],
-            ['jjj'],
-            ['kkk'],
-            ['lll'],
-            ['mmm'],
-            ['nnn'],
-            ['ooo'],
-            ['ppp'],
-            ['qqq'],
-            ['rrr'],
-            ['sss'],
-            ['ttt'],
-            ['uuu'],
-            ['vvv'],
-            ['www'],
-            ['xxx'],
-            ['yyy'],
-            ['zzz'],
-            [''],
             ['aaa100'],
             ['a0'],
             ['z10'],
             ['z99'],
+            ['ça'],
+            ['日'],
         ];
     }
 
     public function provideUnsafeValueIsEscapedData(): array
     {
         return [
-            ['foo_bar'],
-            ['FOO_BAR'],
+            [''],
+            ['__FooBar__'],
             ['_'],
             ['__'],
             ['\''],

--- a/tests/Unit/Traits/EscapeTraitTest.php
+++ b/tests/Unit/Traits/EscapeTraitTest.php
@@ -65,11 +65,6 @@ class EscapeTraitTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testValueWithBacktickIsProperlyEscaped()
-    {
-        $this->assertSame('`foo``bar`', $this->trait->escape("foo`bar"));
-    }
-
     public function provideSafeValueIsNotEscapedData(): array
     {
         return [
@@ -102,6 +97,25 @@ class EscapeTraitTest extends TestCase
             ['100'],
             ['1'],
             ['2'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideValueWithBacktickIsProperlyEscapedData
+     */
+    public function testValueWithBacktickIsProperlyEscaped($input, $expected)
+    {
+        $this->assertSame('`foo``bar`', $this->trait->escape("foo`bar"));
+    }
+
+    public function provideValueWithBacktickIsProperlyEscapedData(): array
+    {
+        return [
+            ['foo`bar','`foo``bar`'],
+            ['`foo','```foo`'],
+            ['foo`','`foo```'],
+            ['foo``bar','`foo````bar`'],
+            ['`foo`','```foo```'],
         ];
     }
 }


### PR DESCRIPTION
I did change some tests and stuff so maybe you want to have a look at it.

The main differences are in how backticks are handled (tested it on 4.3.3 and it worked) and the types of string that are escaped (now, all "invalid" names are escaped instead of some arbitrary superset.).

Moved some name validation code to the escape trait as these names are valid CYPHER when properly escaped.